### PR TITLE
[OWL-414] API - 修復hootgroup count & null value of rrd return

### DIFF
--- a/grpc/query_server.go
+++ b/grpc/query_server.go
@@ -87,6 +87,9 @@ func (s *server) Query(ctx context.Context, in *pb.QueryInput) (*pb.QueryReply, 
 	resTmp := rrdQuery(in)
 	if len(resTmp) == 1 {
 		result := resTmp[0]
+		if result.Values == nil {
+			result.Values = []*cmodel.RRDData{}
+		}
 		//genreate json string and send back to client
 		res, _ := json.Marshal(result)
 		return &pb.QueryReply{Result: string(res)}, nil

--- a/model/dashboard/host_group.go
+++ b/model/dashboard/host_group.go
@@ -91,7 +91,7 @@ func getHostsByHostIds(hostId []int64) (hosts []Hosts, err error) {
 func CountNumOfHostGroup() (c int, err error) {
 	var h []HostGroup
 	q := getOrmObj()
-	_, err = q.Raw("select * from `grp_host`").QueryRows(&h)
+	_, err = q.Raw("select * from `grp`").QueryRows(&h)
 	c = len(h)
 	return
 }


### PR DESCRIPTION
修復兩個後端API問題
1. Nav bar hostgroup 抓到host的數字
2. RRD query result Values 如果沒有資料會顯示null, 應該修復成[] 讓前端在拿資料時不會發生問題.
