### PR TITLE
[OWL-606] fix the "view all alarms privilege"

### DIFF
--- a/model/falcon_portal/event_orm_help.go
+++ b/model/falcon_portal/event_orm_help.go
@@ -2,14 +2,16 @@ package falconPortal
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/Cepave/fe/model/uic"
 	"github.com/astaxie/beego/orm"
-	"log"
 )
 
 func getUserRole(username string) (int64, bool) {
 	user := uic.ReadUserByName(username)
-	if user.Role == 2 {
+	// Role of root is 2. Role of admin assigned by root is 1.
+	if user.Role == 2 || user.Role == 1 {
 		return user.Id, true
 	} else {
 		return user.Id, false

--- a/model/falcon_portal/models.go
+++ b/model/falcon_portal/models.go
@@ -61,6 +61,6 @@ type Action struct {
 	Callback           int    `json:"callback"`
 	BeforeCallbackSms  int    `json:"before_callback_sms"`
 	BeforeCallbackMail int    `json:"before_callback_mail"`
-	AfterCallbackSms   int    `json"after_callback_sms"`
+	AfterCallbackSms   int    `json:"after_callback_sms"`
 	AfterCallbackMail  int    `json:"after_callback_mail"`
 }


### PR DESCRIPTION
Originally, only user.role==2 can view all the alarms.
Now both user.role==1 and user.role==2 can view all the alarms.
## How to verify
1. 建立4個users
   aaa, bbb, ccc, ddd
2. 以aaa user設置報警規則，host group, template, 等。所以aaa一定可以在owl 畫面看得到報警。
3.  透過mysql修改role。
   
   ```
   mysql -h 10.20.30.40 -u root -p 
   > use uic;
   > update user set role=[0,1,2] where id=[N];
   ```
   
   修改 bbb, ccc, ddd的 user.role 屬性。
4. 分別以bbb, ccc, ddd登入owl UI，看是否符合：
   user.role =1 或 2時，可以看到所有的報警。
   user.role != 1 或2 時，且沒有設置對應的user group，就會看不到所有的報警。
   注意：做步驟3的測試時，需要登入redis 的docker，
   
   ```
   $ redis-cli
   > flushall
   ```
   
   讓redis裡的資料清空，這樣子才會是最正確的結果。
